### PR TITLE
Added uniqueSuiteNames property to maven mojo

### DIFF
--- a/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/JUnit4.java
+++ b/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/JUnit4.java
@@ -188,6 +188,9 @@ public class JUnit4 extends Task {
   /** Default value of {@link #setSysouts}. */
   public static final boolean DEFAULT_SYSOUTS = false;
 
+  /** Default value of {@link #setUniqueSuiteNames(boolean)} */
+  public static final boolean DEFAULT_UNIQUE_SUITE_NAME = true;
+
   /** System property passed to forked VMs: current working directory (absolute). */
   private static final String CHILDVM_SYSPROP_CWD = "junit4.childvm.cwd";
 
@@ -231,7 +234,7 @@ public class JUnit4 extends Task {
   /**
    * @see #setUniqueSuiteNames
    */
-  private boolean uniqueSuiteNames = true;
+  private boolean uniqueSuiteNames = DEFAULT_UNIQUE_SUITE_NAME;
   
   /**
    * Environment variables to use in the forked JVM.

--- a/junit4-maven-plugin/src/main/java/com/carrotsearch/maven/plugins/junit4/JUnit4Mojo.java
+++ b/junit4-maven-plugin/src/main/java/com/carrotsearch/maven/plugins/junit4/JUnit4Mojo.java
@@ -312,6 +312,15 @@ public class JUnit4Mojo extends AbstractMojo {
    * @parameter property="jvmOutputAction" default-value="pipe,warn"
    */
   private String jvmOutputAction;
+
+  /**
+   * Allows or disallow duplicate suite names in resource collections. By default this option
+   * is <code>true</code> because certain ANT-compatible report types (like XML reports)
+   * will have a problem with duplicate suite names (will overwrite files).
+   *
+   * @parameter default-value="true"
+   */
+  private boolean uniqueSuiteNames = JUnit4.DEFAULT_UNIQUE_SUITE_NAME;
   
   /**
    * Raw listeners configuration. Same XML as for ANT.
@@ -549,6 +558,7 @@ public class JUnit4Mojo extends AbstractMojo {
     junit4.addAttribute("leaveTemporary", Boolean.toString(leaveTemporary));
     junit4.addAttribute("dynamicAssignmentRatio", Float.toString(dynamicAssignmentRatio));
     junit4.addAttribute("sysouts", Boolean.toString(sysouts));
+    junit4.addAttribute("uniqueSuiteNames", Boolean.toString(uniqueSuiteNames));
 
     // JVM args.
     for (String jvmArg : Objects.firstNonNull(jvmArgs, EMPTY_STRING_ARRAY)) {


### PR DESCRIPTION
This PR makes it possible to set uniqueSuiteNames to false through maven plugin configuration, as the property wasn't previously exposed to the maven mojo.
