### PR TITLE
print test seed chain in REPRODUCE string

### DIFF
--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/ReproduceErrorMessageBuilder.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/ReproduceErrorMessageBuilder.java
@@ -36,7 +36,9 @@ public class ReproduceErrorMessageBuilder {
     RandomizedContext ctx = null;
     try {
       ctx = RandomizedContext.current();
-      appendOpt(SYSPROP_RANDOM_SEED(), ctx.getRunnerSeedAsString());
+      Randomness [] seeds = RandomizedContext.current().getRandomnesses();
+      final String seedChain = SeedUtils.buildSeedChain(seeds);
+      appendOpt(SYSPROP_RANDOM_SEED(), seedChain);
     } catch (IllegalStateException e) {
       logger.warning("No context available when dumping reproduce options?");
     }

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/SeedUtils.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/SeedUtils.java
@@ -60,11 +60,17 @@ public final class SeedUtils {
   public static String formatSeedChain(Randomness... randomnesses) {
     StringBuilder b = new StringBuilder();
     b.append("[");
+    b.append(buildSeedChain(randomnesses));
+    b.append("]");
+    return b.toString();
+  }
+
+  public static String buildSeedChain(Randomness... randomnesses) {
+    StringBuilder b = new StringBuilder();
     for (int i = 0; i < randomnesses.length; i++) {
       if (i > 0) b.append(":");
       b.append(formatSeed(randomnesses[i].getSeed()));
     }
-    b.append("]");
     return b.toString();
   }
 }

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/listeners/ReproduceInfoPrinter.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/listeners/ReproduceInfoPrinter.java
@@ -15,9 +15,15 @@ public class ReproduceInfoPrinter extends RunListener {
 
   @Override
   public void testFailure(Failure failure) throws Exception {
+    final StringBuilder b = buildReproduceInfo(failure);
+    if (b == null) return;
+    System.err.println(b.toString());
+  }
+
+  protected StringBuilder buildReproduceInfo(Failure failure) {
     // Ignore assumptions.
     if (failure.getException() instanceof AssumptionViolatedException) {
-      return;
+      return null;
     }
 
     final Description d = failure.getDescription();
@@ -38,7 +44,6 @@ public class ReproduceInfoPrinter extends RunListener {
       }
       traces.formatThrowable(b, failure.getException());
     }
-
-    System.err.println(b.toString());
+    return b;
   }
 }

--- a/randomized-runner/src/test/java/com/carrotsearch/randomizedtesting/TestReproduceStringSeed.java
+++ b/randomized-runner/src/test/java/com/carrotsearch/randomizedtesting/TestReproduceStringSeed.java
@@ -1,0 +1,22 @@
+package com.carrotsearch.randomizedtesting;
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+import static org.junit.internal.matchers.StringContains.containsString;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@Seed("deadbeef")
+public class TestReproduceStringSeed extends RandomizedTest {
+  @Seed("cafebabe")
+  @Test
+  public void testErrorStringIsBuiltCorrectly() {
+    final StringBuilder b = new StringBuilder();
+    Description description = Description.createTestDescription(TestReproduceStringSeed.class, "testErrorStringIsBuiltCorrectly");
+    new ReproduceErrorMessageBuilder(b).appendAllOpts(description);
+    assertThat(b.toString(), containsString("DEADBEEF:CAFEBABE"));
+    assertFalse(b.toString().contains("[DEADBEEF:CAFEBABE]"));
+  }
+}


### PR DESCRIPTION
It would be nice to have the whole seed chain in the reproduce
string. This way one only has to add a test.iters=N behind it to
run the test in a loop.

I assume this is needed because of https://github.com/elasticsearch/elasticsearch/commit/aa3897280c17979f79bfcc29072b40dcca519739
Does that make sense? Or is there any other way to achieve this?
