### PR TITLE
Add util method to execute code in private random context

### DIFF
--- a/randomized-runner/src/test/java/com/carrotsearch/randomizedtesting/TestRandomizedContext.java
+++ b/randomized-runner/src/test/java/com/carrotsearch/randomizedtesting/TestRandomizedContext.java
@@ -1,0 +1,45 @@
+package com.carrotsearch.randomizedtesting;
+
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+/**
+ */
+public class TestRandomizedContext extends RandomizedTest {
+
+  @Test
+  public void testRunWithPrivateRandomness() throws Exception {
+    final int iters = randomIntBetween(1, 10);
+    for (int j = 0; j < iters; j++) {
+      final long seed = randomLong();
+      final int[] first = RandomizedContext.current().runWithPrivateRandomness(new Randomness(seed), new Callable<int[]>() {
+        @Override
+        public int[] call() throws Exception {
+          final int size = randomIntBetween(10, 1000);
+          final int[] result = new int[size];
+          for (int i = 0; i < size; i++) {
+            result[i] = randomInt();
+          }
+          return result;
+        }
+      });
+      assertNotNull(first);
+      final int[] second = RandomizedContext.current().runWithPrivateRandomness(new Randomness(seed), new Callable<int[]>() {
+        @Override
+        public int[] call() throws Exception {
+          final int size = randomIntBetween(10, 1000);
+          final int[] result = new int[size];
+          for (int i = 0; i < size; i++) {
+            result[i] = randomInt();
+          }
+          return result;
+        }
+      });
+      assertNotNull(second);
+      assertNotSame(first, second);
+      assertArrayEquals("first and second sequence must be identical", first, second);
+    }
+  }
+
+}


### PR DESCRIPTION
Today calls to RandomizedTest#randomInt() etc. always use the current
thread local context and the randomness on top of it's stack. In certain
situations for instance if a method produces a configuration or a infrastructure
resource that should be reproducible calls using the threadlocal context can poision
the random sequence and destroy reproducibilty. This commit adds a utiltiy
that allows to run such a method with a new randomness instance to ensure reproducibiilty
even if the code that is executed in this context uses the threadlocal random context.
