### PR TITLE
Move to Java 1.7 and use the java NIO 2 API for temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 
 *.versionsBackup
 *.swp
+*.iml

--- a/etc/eclipse/.settings/org.eclipse.jdt.core.prefs
+++ b/etc/eclipse/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 #Thu Jan 26 09:50:07 CET 2012
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.source=1.7
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0

--- a/examples/ant/build.xml
+++ b/examples/ant/build.xml
@@ -1,7 +1,7 @@
 
 <project default="test" xmlns:junit4="antlib:com.carrotsearch.junit4">
     <presetdef name="javac">
-        <javac deprecation="false" debug="true" target="1.6" source="1.6" encoding="UTF-8" includeantruntime="false" />
+        <javac deprecation="false" debug="true" target="1.7" source="1.7" encoding="UTF-8" includeantruntime="false" />
     </presetdef>
 
     <property name="tmp.dir" location="${basedir}/target" />

--- a/junit4-maven-plugin-tests/src/it/01-basic-test/pom.xml
+++ b/junit4-maven-plugin-tests/src/it/01-basic-test/pom.xml
@@ -16,8 +16,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>    
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>    
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
 
     <skip.deployment>false</skip.deployment>
 

--- a/randomized-runner/pom.xml
+++ b/randomized-runner/pom.xml
@@ -110,7 +110,7 @@
         <version>2.3.4</version>
         <configuration>
           <instructions>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>${project.groupId}.*;version="${project.version}"</Export-Package>
           </instructions>

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/TempPathResource.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/TempPathResource.java
@@ -1,6 +1,8 @@
 package com.carrotsearch.randomizedtesting;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A temporary path resource will be deleted at the end of a given lifecycle phase.
@@ -9,16 +11,16 @@ import java.io.*;
  * @see RandomizedTest#newTempDir()
  */
 public class TempPathResource implements Closeable {
-  private final File location;
+  private final Path location;
 
-  public TempPathResource(File location) {
+  public TempPathResource(Path location) {
     this.location = location;
   }
 
   public void close() throws IOException {
     RandomizedTest.forceDeleteRecursively(location);
-    if (location.exists())
+    if (Files.exists(location))
       throw new IOException("Could not remove path: "
-          + location.getAbsolutePath());
+          + location.toAbsolutePath());
   }
 }

--- a/randomized-runner/src/test/java/com/carrotsearch/randomizedtesting/TestRandomizedTest.java
+++ b/randomized-runner/src/test/java/com/carrotsearch/randomizedtesting/TestRandomizedTest.java
@@ -4,6 +4,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.channels.FileChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -108,29 +112,30 @@ public class TestRandomizedTest extends RandomizedTest {
   }
 
   @Test
-  public void testNewTempDir() {
+  public void testNewTempDir() throws IOException {
     for (int i = 0; i < 10; i++) {
-      File dir = newTempDir();
+      Path dir = newTempDir();
       assertNotNull(dir);
-      assertTrue(dir.isDirectory());
-      assertTrue(dir.canWrite());
-      assertTrue(dir.canRead());
-      assertTrue(dir.canExecute());
-      assertEquals(0, dir.listFiles().length);
+      assertTrue(Files.isDirectory(dir));
+      assertTrue(Files.isWritable(dir));
+      assertTrue(Files.isReadable(dir));
+      assertTrue(Files.isExecutable(dir));
+      try (DirectoryStream<Path> path = Files.newDirectoryStream(dir)) {
+        assertFalse(path.iterator().hasNext());
+      }
     }
   }
 
   @Test
   public void testNewTempFile() throws IOException {
     for (int i = 0; i < 10; i++) {
-      File file = newTempFile();
+      Path file = newTempFile();
       assertNotNull(file);
-      assertTrue(file.isFile());
-      assertTrue(file.canWrite());
-      assertTrue(file.canRead());
-      assertTrue(file.getName().indexOf(' ') >= 0);
-
-      new FileOutputStream(file).close();
+      assertTrue(Files.isRegularFile(file));
+      assertTrue(Files.isWritable(file));
+      assertTrue(Files.isReadable(file));
+      assertTrue(file.getFileName().toString().indexOf(' ') >= 0);
+      Files.newOutputStream(file).close();
     }
   }
 


### PR DESCRIPTION
I think it's time to move to Java 1.7 and expose the temp file / dir APIs via java nio2. it's simple to get the old File from it by calling `toFile()`