### PR TITLE
Added rule to easily print the seed when a test fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 .classpath
 .settings
 .idea
+**/*.iml
 
 *.versionsBackup
 *.swp

--- a/examples/maven/src/main/java/com/carrotsearch/examples/randomizedrunner/Test016PrintSeedOnErrorRule.java
+++ b/examples/maven/src/main/java/com/carrotsearch/examples/randomizedrunner/Test016PrintSeedOnErrorRule.java
@@ -1,0 +1,36 @@
+package com.carrotsearch.examples.randomizedrunner;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.rules.PrintSeedOnErrorRule;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A simple test which introduces the {@link PrintSeedOnErrorRule}. This JUnit-Rule allows the user to easily print the seed with which a test has
+ * failed if and only if it fails. This allows for easier reproducability without clogging the output.
+ *
+ * @author blalasaadri
+ */
+@RunWith(RandomizedRunner.class)
+@Seed("B3D0ED05E80E2276")
+public class Test016PrintSeedOnErrorRule {
+
+    @Rule
+    public PrintSeedOnErrorRule printSeedOnErrorRule = new PrintSeedOnErrorRule();
+
+    @Test
+    public void failQuickly() {
+        // Will print the seed
+        Assert.fail();
+    }
+
+    @Test
+    public void dontFail() {
+        // Will not print the seed
+        Assert.assertTrue(true);
+    }
+
+}

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/PrintSeedOnErrorRule.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/PrintSeedOnErrorRule.java
@@ -1,0 +1,29 @@
+package com.carrotsearch.randomizedtesting.rules;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Simple rule which prints the test seed only if a test fails.
+ *
+ * @author blalasaadri
+ */
+public class PrintSeedOnErrorRule implements TestRule {
+
+    @Override
+    public Statement apply(final Statement statement, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    statement.evaluate();
+                } catch(AssertionError e) {
+                    System.err.println("Test failed with seed: " + RandomizedContext.current().getRunnerSeedAsString());
+                    throw e;
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
This rule allows the user to easily print the seed if and only if a test fails. Thereby the test output will not be clogged with unnecessary entries and debugging is easier.