### PR TITLE
Add a security-manager test/example and clean up permissions

### DIFF
--- a/examples/security-manager/pom.xml
+++ b/examples/security-manager/pom.xml
@@ -73,6 +73,7 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <tasks>
+                <makeurl file="${junit:junit:jar}" property="junit.jar.url"/>
                 <makeurl file="${com.carrotsearch.randomizedtesting:junit4-ant:jar}" property="junit4.jar.url"/>
                 <makeurl file="${com.carrotsearch.randomizedtesting:randomizedtesting-runner:jar}" property="randomizedtesting.jar.url"/>
               </tasks>
@@ -94,6 +95,7 @@
             <configuration>
               <rules>
                 <requireProperty>
+                  <property>junit.jar.url</property>
                   <property>junit4.jar.url</property>
                   <property>randomizedtesting.jar.url</property>
                 </requireProperty>
@@ -150,6 +152,7 @@
                 <param>-Djava.security.manager</param>
                 <param>-Djava.security.policy==${project.basedir}/security.policy</param>
                 <!-- pass for debugging <param>-Djava.security.debug=policy</param> -->
+                <param>-Djunit.jar.url=${junit.jar.url}</param>
                 <param>-Djunit4.jar.url=${junit4.jar.url}</param>
                 <param>-Drandomizedtesting.jar.url=${randomizedtesting.jar.url}</param>
               </jvmArgs>

--- a/examples/security-manager/pom.xml
+++ b/examples/security-manager/pom.xml
@@ -1,0 +1,161 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.carrotsearch.randomizedtesting</groupId>
+    <artifactId>randomizedtesting-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>randomizedtesting-security-manager-example</artifactId>
+  <name>RandomizedTesting Security Manager Example</name>
+
+  <description>
+    Simple use-case running with security manager
+  </description>
+
+  <properties>
+    <skip.deployment>false</skip.deployment>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.carrotsearch.randomizedtesting</groupId>
+      <artifactId>randomizedtesting-runner</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.carrotsearch.randomizedtesting</groupId>
+      <artifactId>junit4-ant</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- We don't want to use surefire to run our tests so we skip it. -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <skipTests>true</skipTests>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <!-- 
+         Set property of the url to each dependency
+         We use antrun to turn path into a proper URL (for windows with spaces etc)
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <tasks>
+                <makeurl file="${com.carrotsearch.randomizedtesting:junit4-ant:jar}" property="junit4.jar.url"/>
+                <makeurl file="${com.carrotsearch.randomizedtesting:randomizedtesting-runner:jar}" property="randomizedtesting.jar.url"/>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- fail build in a clean way, if something gets screwed up -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-urls-were-set</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>junit4.jar.url</property>
+                  <property>randomizedtesting.jar.url</property>
+                </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Run tests with JUnit4 under security manager -->
+      <plugin>
+        <groupId>com.carrotsearch.randomizedtesting</groupId>
+        <artifactId>junit4-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>junit4-tests</id>
+            <goals>
+              <goal>junit4</goal>
+            </goals>
+            <!-- run in integration-test phase, so jars are "like production" for permission -->
+            <phase>integration-test</phase>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              
+              <!-- Our tests are in primary classes folder. -->
+              <!-- <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory> -->
+
+              <!-- Attach a simple listener. -->
+              <listeners>
+                <report-text
+                    showThrowable="true" 
+                    showStackTraces="true" 
+                    showOutput="onerror" 
+
+                    showStatusOk="true"
+                    showStatusError="true"
+                    showStatusFailure="true"
+                    showStatusIgnored="true"
+
+                    showSuiteSummary="false"
+                />
+
+                <!-- JSON report with HTML scaffolding. -->
+                <report-json file="${dir.ant.tests}/result-json/results.html" />
+              </listeners>
+
+              <assertions>
+                <enable package="com.carrotsearch"/>
+              </assertions>
+
+              <!-- do all system properties here, to avoid policy hell! -->
+              <jvmArgs>
+                <param>-Djava.security.manager</param>
+                <param>-Djava.security.policy==${project.basedir}/security.policy</param>
+                <!-- pass for debugging <param>-Djava.security.debug=policy</param> -->
+                <param>-Djunit4.jar.url=${junit4.jar.url}</param>
+                <param>-Drandomizedtesting.jar.url=${randomizedtesting.jar.url}</param>
+              </jvmArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/security-manager/pom.xml
+++ b/examples/security-manager/pom.xml
@@ -133,8 +133,9 @@
                     showStatusFailure="true"
                     showStatusIgnored="true"
 
-                    showSuiteSummary="false"
-                />
+                    showSuiteSummary="false">
+                    <filtertrace enabled="false"/>
+                </report-text>
 
                 <!-- JSON report with HTML scaffolding. -->
                 <report-json file="${dir.ant.tests}/result-json/results.html" />

--- a/examples/security-manager/security.policy
+++ b/examples/security-manager/security.policy
@@ -1,0 +1,26 @@
+// policy file for tests
+
+//// These permissions apply to the JDK itself
+//// (actually only needed for "extensions")
+
+grant codeBase "file:${{java.ext.dirs}}/*" {
+  permission java.security.AllPermission;
+};
+
+//// permission for the junit4 runner jar
+grant codeBase "${junit4.jar.url}" {
+  // gson serialization requires this
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+};
+
+//// permissions for the randomized runner jar
+grant codeBase "${randomizedtesting.jar.url}" {
+  // nothing yet, coming soon!
+};
+
+//// Test class permission: we want this to be minimal!
+grant {
+  permission java.util.PropertyPermission "*", "read,write";
+  permission java.io.FilePermission "<<ALL FILES>>", "read,readlink,write,delete,execute";
+  permission java.lang.RuntimePermission "*";
+};

--- a/examples/security-manager/security.policy
+++ b/examples/security-manager/security.policy
@@ -7,21 +7,37 @@ grant codeBase "file:${{java.ext.dirs}}/*" {
   permission java.security.AllPermission;
 };
 
-//// permission for the junit4 runner jar
+//// permission for the junit4 jar
 grant codeBase "${junit4.jar.url}" {
   // gson serialization requires this
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  // needed for io stream handling
+  permission java.lang.RuntimePermission "setIO";
 };
 
 //// permissions for the randomized runner jar
 grant codeBase "${randomizedtesting.jar.url}" {
   // optionally needed for access to private test methods (e.g. beforeClass)
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  // needed to handle uncaught exceptions from other threads
+  permission java.lang.RuntimePermission "setDefaultUncaughtExceptionHandler";
+  // needed for getTopThreads
+  permission java.lang.RuntimePermission "modifyThreadGroup";
+  // needed for TestClass creation
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  // needed for ThreadLeakControl
+  permission java.lang.RuntimePermission "getStackTrace";
+};
+
+//// permissions for the junit jar
+grant codeBase "${junit.jar.url}" {
+  // needed for TestClass creation
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
 //// Test class permission: we want this to be minimal!
 grant {
   permission java.util.PropertyPermission "*", "read,write";
   permission java.io.FilePermission "<<ALL FILES>>", "read,readlink,write,delete,execute";
-  permission java.lang.RuntimePermission "*";
 };

--- a/examples/security-manager/security.policy
+++ b/examples/security-manager/security.policy
@@ -15,7 +15,8 @@ grant codeBase "${junit4.jar.url}" {
 
 //// permissions for the randomized runner jar
 grant codeBase "${randomizedtesting.jar.url}" {
-  // nothing yet, coming soon!
+  // optionally needed for access to private test methods (e.g. beforeClass)
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
 //// Test class permission: we want this to be minimal!

--- a/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/DelegatingRunner.java
+++ b/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/DelegatingRunner.java
@@ -1,0 +1,41 @@
+package com.carrotsearch.examples.randomizedrunner;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.Filterable;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+
+/** Pollutes the stack with non-RR code, so we know the AccessController
+    blocks are correct. */
+public class DelegatingRunner extends Runner implements Filterable {
+  private final RandomizedRunner delegate;
+  
+  public DelegatingRunner(Class<?> testClass) throws InitializationError {
+    delegate = new RandomizedRunner(testClass);
+  }
+
+  @Override
+  public int testCount() {
+    return delegate.testCount();
+  }
+
+  @Override
+  public void filter(Filter filter) throws NoTestsRemainException {
+    delegate.filter(filter);    
+  }
+
+  @Override
+  public Description getDescription() {
+    return delegate.getDescription();
+  }
+
+  @Override
+  public void run(RunNotifier notifier) {
+    delegate.run(notifier);
+  }
+}

--- a/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/TestExample.java
+++ b/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/TestExample.java
@@ -1,4 +1,4 @@
-package com.carrotsearch.examples.randomizedrunner.reports;
+package com.carrotsearch.examples.randomizedrunner;
 
 import junit.framework.Assert;
 import org.junit.BeforeClass;
@@ -6,18 +6,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.carrotsearch.randomizedtesting.JUnit4MethodProvider;
-import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.carrotsearch.randomizedtesting.MixWithSuiteName;
-import com.carrotsearch.randomizedtesting.RandomizedContext;
-import com.carrotsearch.randomizedtesting.RandomizedRunner;
-import com.carrotsearch.randomizedtesting.RandomizedTest;
-import com.carrotsearch.randomizedtesting.annotations.Listeners;
 import com.carrotsearch.randomizedtesting.annotations.SeedDecorators;
-import com.carrotsearch.randomizedtesting.annotations.TestGroup;
 import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakAction.Action;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakAction;
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakGroup.Group;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakGroup;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
@@ -26,12 +19,8 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakZombies.Consequence;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakZombies;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
-import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-import com.carrotsearch.randomizedtesting.rules.NoClassHooksShadowingRule;
-import com.carrotsearch.randomizedtesting.rules.NoInstanceHooksOverridesRule;
-import com.carrotsearch.randomizedtesting.rules.StaticFieldsInvariantRule;
 
-@RunWith(RandomizedRunner.class)
+@RunWith(DelegatingRunner.class)
 @TestMethodProviders({
   JUnit4MethodProvider.class
 })

--- a/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/TestExample.java
+++ b/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/TestExample.java
@@ -1,6 +1,7 @@
 package com.carrotsearch.examples.randomizedrunner.reports;
 
 import junit.framework.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,9 +44,14 @@ import com.carrotsearch.randomizedtesting.rules.StaticFieldsInvariantRule;
 @TimeoutSuite(millis = 200000000)
 public class TestExample extends Assert {
 
+  @BeforeClass
+  private static void beforeClassPrivate() {
+    System.out.println("beforeClassPrivate");
+  }
+
   @Test
   public void test() {
-    System.out.println("hello");
+    System.out.println("test");
   }
 
 }

--- a/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/TestExample.java
+++ b/examples/security-manager/src/test/java/com/carrotsearch/examples/randomizedrunner/TestExample.java
@@ -1,0 +1,51 @@
+package com.carrotsearch.examples.randomizedrunner.reports;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.carrotsearch.randomizedtesting.JUnit4MethodProvider;
+import com.carrotsearch.randomizedtesting.LifecycleScope;
+import com.carrotsearch.randomizedtesting.MixWithSuiteName;
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.annotations.Listeners;
+import com.carrotsearch.randomizedtesting.annotations.SeedDecorators;
+import com.carrotsearch.randomizedtesting.annotations.TestGroup;
+import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakAction.Action;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakAction;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakGroup.Group;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakGroup;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakZombies.Consequence;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakZombies;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import com.carrotsearch.randomizedtesting.rules.NoClassHooksShadowingRule;
+import com.carrotsearch.randomizedtesting.rules.NoInstanceHooksOverridesRule;
+import com.carrotsearch.randomizedtesting.rules.StaticFieldsInvariantRule;
+
+@RunWith(RandomizedRunner.class)
+@TestMethodProviders({
+  JUnit4MethodProvider.class
+})
+@SeedDecorators({MixWithSuiteName.class}) // See LUCENE-3995 for rationale.
+@ThreadLeakScope(Scope.SUITE)
+@ThreadLeakGroup(Group.MAIN)
+@ThreadLeakAction({Action.WARN, Action.INTERRUPT})
+@ThreadLeakLingering(linger = 20000) // Wait long for leaked threads to complete before failure. zk needs this.
+@ThreadLeakZombies(Consequence.IGNORE_REMAINING_TESTS)
+@TimeoutSuite(millis = 200000000)
+public class TestExample extends Assert {
+
+  @Test
+  public void test() {
+    System.out.println("hello");
+  }
+
+}

--- a/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/events/Serializer.java
+++ b/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/events/Serializer.java
@@ -93,13 +93,14 @@ public class Serializer implements Closeable {
           throw new IOException("Serializer already closed, with " + events.size() + " events on queue.");
         }
 
-        IEvent event = events.removeFirst();
+        final IEvent event = events.removeFirst();
         try {
-          JsonWriter jsonWriter = new JsonWriter(writer);
+          final JsonWriter jsonWriter = new JsonWriter(writer);
           jsonWriter.setIndent("  ");
           jsonWriter.beginArray();
           jsonWriter.value(event.getType().name());
           // serialization requires suppressing access checks!
+          final Gson gson = this.gson;
           AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
             @Override
             public Void run() throws Exception {

--- a/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/events/Serializer.java
+++ b/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/events/Serializer.java
@@ -2,6 +2,8 @@ package com.carrotsearch.ant.tasks.junit4.events;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
 import java.util.ArrayDeque;
 
 import org.junit.runner.Description;
@@ -97,7 +99,14 @@ public class Serializer implements Closeable {
           jsonWriter.setIndent("  ");
           jsonWriter.beginArray();
           jsonWriter.value(event.getType().name());
-          gson.toJson(event, event.getClass(), jsonWriter);
+          // serialization requires suppressing access checks!
+          AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+            @Override
+            public Void run() throws Exception {
+              gson.toJson(event, event.getClass(), jsonWriter);
+              return null;
+            }
+          });
           jsonWriter.endArray();
           writer.write("\n\n");
         } catch (Throwable t) {

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <module>junit4-maven-plugin-tests</module>
     <module>examples/maven</module>
     <module>examples/ant</module>
+    <module>examples/security-manager</module>
     <module>packaging</module>
   </modules>
 

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/RandomizedRunner.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/RandomizedRunner.java
@@ -1640,7 +1640,7 @@ public final class RandomizedRunner extends Runner implements Filterable {
   /**
    * Invoke a given method on a suiteClass instance (can be null for static methods).
    */
-  void invoke(Method m, Object instance, Object... args) throws Throwable {
+  void invoke(final Method m, Object instance, Object... args) throws Throwable {
     if (!Modifier.isPublic(m.getModifiers())) {
       try {
         if (!m.isAccessible()) {

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/RandomizedRunner.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/RandomizedRunner.java
@@ -559,7 +559,13 @@ public final class RandomizedRunner extends Runner implements Filterable {
     // TODO: this effectively means we can't run concurrent randomized runners.
     final UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
     handler = new QueueUncaughtExceptionsHandler();
-    Thread.setDefaultUncaughtExceptionHandler(handler);
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      @Override
+      public Void run() {
+        Thread.setDefaultUncaughtExceptionHandler(handler);
+        return null;
+      }
+    });
 
     this.runnerThreadGroup = new RunnerThreadGroup(
         "TGRP-" + Classes.simpleName(suiteClass));
@@ -601,7 +607,13 @@ public final class RandomizedRunner extends Runner implements Filterable {
               Thread.getDefaultUncaughtExceptionHandler().getClass())));
     }
 
-    Thread.setDefaultUncaughtExceptionHandler(previous);
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      @Override
+      public Void run() {
+        Thread.setDefaultUncaughtExceptionHandler(previous);
+        return null;
+      }
+    });
     runnerThreadGroup = null;
     handler = null;
   }
@@ -996,7 +1008,12 @@ public final class RandomizedRunner extends Runner implements Filterable {
    */
   private <T> List<T> getAnnotatedFieldValues(Object test,
       Class<? extends Annotation> annotationClass, Class<T> valueClass) {
-    TestClass info = new TestClass(suiteClass);
+    TestClass info = AccessController.doPrivileged(new PrivilegedAction<TestClass>() {
+      @Override
+      public TestClass run() {
+        return new TestClass(suiteClass);
+      }
+    });
     List<T> results = new ArrayList<T>();
 
     List<FrameworkField> annotatedFields = 

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/RandomizedRunner.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/RandomizedRunner.java
@@ -15,6 +15,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1625,7 +1627,12 @@ public final class RandomizedRunner extends Runner implements Filterable {
     if (!Modifier.isPublic(m.getModifiers())) {
       try {
         if (!m.isAccessible()) {
-          m.setAccessible(true);
+          AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+              m.setAccessible(true);
+              return null;
+            }});
         }
       } catch (SecurityException e) {
         throw new RuntimeException("There is a non-public method that needs to be called. This requires " +

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/StaticFieldsInvariantRule.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/StaticFieldsInvariantRule.java
@@ -93,7 +93,7 @@ public class StaticFieldsInvariantRule implements TestRule {
         ArrayList<Entry> fieldsAndValues = new ArrayList<Entry>();
         ArrayList<Object> values = new ArrayList<Object>();
         for (Class<?> c = testClass; countSuperclasses && c.getSuperclass() != null; c = c.getSuperclass()) {
-          for (Field field : c.getDeclaredFields()) {
+          for (final Field field : c.getDeclaredFields()) {
             if (Modifier.isStatic(field.getModifiers()) && 
                 !field.getType().isPrimitive() &&
                 accept(field)) {

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/StaticFieldsInvariantRule.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/StaticFieldsInvariantRule.java
@@ -2,6 +2,8 @@ package com.carrotsearch.randomizedtesting.rules;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -96,7 +98,13 @@ public class StaticFieldsInvariantRule implements TestRule {
                 !field.getType().isPrimitive() &&
                 accept(field)) {
               try {
-                field.setAccessible(true);
+                AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                  @Override
+                  public Void run() {
+                    field.setAccessible(true);
+                    return null;
+                  }
+                });
                 Object v = field.get(null);
                 if (v != null) {
                   fieldsAndValues.add(new Entry(field, v));


### PR DESCRIPTION
This makes it possible to reduce the tons of permissions needed currently, and only grant them to the test jar.
