### PR TITLE
Access private fields within doPrivileged

### DIFF
--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/RamUsageEstimator.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/RamUsageEstimator.java
@@ -444,7 +444,13 @@ final class RamUsageEstimator {
     
     // Walk type hierarchy
     for (;clazz != null; clazz = clazz.getSuperclass()) {
-      final Field[] fields = clazz.getDeclaredFields();
+      final Class<?> target = clazz;
+      final Field[] fields = AccessController.doPrivileged(new PrivilegedAction<Field[]>() {
+        @Override
+        public Field[] run() {
+          return target.getDeclaredFields();
+        }
+      });
       for (Field f : fields) {
         if (!Modifier.isStatic(f.getModifiers())) {
           size = adjustForField(size, f);
@@ -572,7 +578,13 @@ final class RamUsageEstimator {
     long shallowInstanceSize = NUM_BYTES_OBJECT_HEADER;
     final ArrayList<Field> referenceFields = new ArrayList<Field>(32);
     for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
-      final Field[] fields = c.getDeclaredFields();
+      final Class<?> target = clazz;
+      final Field[] fields = AccessController.doPrivileged(new PrivilegedAction<Field[]>() {
+        @Override
+        public Field[] run() {
+          return target.getDeclaredFields();
+        }
+      });
       for (final Field f : fields) {
         if (!Modifier.isStatic(f.getModifiers())) {
           shallowInstanceSize = adjustForField(shallowInstanceSize, f);

--- a/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/StaticFieldsInvariantRule.java
+++ b/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/rules/StaticFieldsInvariantRule.java
@@ -93,7 +93,14 @@ public class StaticFieldsInvariantRule implements TestRule {
         ArrayList<Entry> fieldsAndValues = new ArrayList<Entry>();
         ArrayList<Object> values = new ArrayList<Object>();
         for (Class<?> c = testClass; countSuperclasses && c.getSuperclass() != null; c = c.getSuperclass()) {
-          for (final Field field : c.getDeclaredFields()) {
+          final Class<?> target = c;
+          Field[] allFields = AccessController.doPrivileged(new PrivilegedAction<Field[]>() {
+            @Override
+            public Field[] run() {
+              return target.getDeclaredFields();
+            }
+          });
+          for (final Field field : allFields) {
             if (Modifier.isStatic(field.getModifiers()) && 
                 !field.getType().isPrimitive() &&
                 accept(field)) {


### PR DESCRIPTION
RamUsageEstimator/StaticFieldsInvariantRule do some inspection of private
members... but this requires `RuntimePermission("accessDeclaredMembers")` to do.

It would be nice to just grant this to the randomizedrunner jar.
