### PR TITLE
Bump ASM to latest 9.2 to support JDK 17

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@ RandomizedTesting, Change Log
 For an up-to-date CHANGES file see 
 https://github.com/randomizedtesting/randomizedtesting/blob/master/CHANGES
 
+======================= randomizedtesting 2.7.10-SNAPSHOT ====================
+
+Other:
+
+  * Update ASM to 9.2 to support JDK 17
+
 ======================= randomizedtesting 2.7.9-SNAPSHOT ====================
 
 Other:

--- a/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/JUnit4.java
+++ b/junit4-ant/src/main/java/com/carrotsearch/ant/tasks/junit4/JUnit4.java
@@ -1835,7 +1835,7 @@ public class JUnit4 extends Task {
             final TestClass testClass = new TestClass();
             ClassReader reader = new ClassReader(is);
             @SuppressWarnings("deprecation")
-            ClassVisitor annotationVisitor = new ClassVisitor(Opcodes.ASM8) {
+            ClassVisitor annotationVisitor = new ClassVisitor(Opcodes.ASM9) {
               @Override
               public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 String className = Type.getType(desc).getClassName();

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>8.0.1</version>
+        <version>9.2</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Hi @dweiss ,

I was working on a project that recently upgraded to JDK 17. We use `randomizedtesting_junit4-ant` for running our tests and `randomizedtesting_randomizedtesting-runner`. The project throws an error like this when we try to run its `release` tasks

```
<our_package>/build-tools/ant/carrot-junit4.xml:244: java.lang.IllegalArgumentException: Unsupported class file major version 61
```

We had another package that was throwing a similar class of error and that got resolved by upgrading its ASM version (in line with the newer JDK17). 

I looked at the [last](https://github.com/randomizedtesting/randomizedtesting/issues/289) time ASM was bumped and pretty much copied the logic.

Testing: 

Ran tests with `mvn -X package` but it throws a myriad of errors. Is this the correct way to test the package?

---

ASM on maven central: https://search.maven.org/artifact/org.ow2.asm/asm/9.2/jar
